### PR TITLE
Show sample ballots and upload form link

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -54,7 +54,8 @@ export default class Api {
     const requestOpts = {
       content_type: 'sampleBallot',
       'fields.ward': ward,
-      'fields.party': party
+      'fields.party': party,
+      'fields.isApproved': true
     }
     if (subWard) requestOpts['fields.subWard'] = subWard
 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -54,8 +54,7 @@ export default class Api {
     const requestOpts = {
       content_type: 'sampleBallot',
       'fields.ward': ward,
-      'fields.party': party,
-      'fields.isApproved': true
+      'fields.party': party
     }
     if (subWard) requestOpts['fields.subWard'] = subWard
 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -50,6 +50,18 @@ export default class Api {
     })
   }
 
+  fetchSampleBallots (ward, subWard, party) {
+    const requestOpts = {
+      content_type: 'sampleBallot',
+      'fields.ward': ward,
+      'fields.party': party
+    }
+    if (subWard) requestOpts['fields.subWard'] = subWard
+
+    return this.client.getEntries(requestOpts)
+    .then((response) => response.items.map(getFieldsAndId))
+  }
+
   fetchCommitteePersons (ward, party) {
     const requestOpts = {
       content_type: 'committeePerson',

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,4 @@
 export const CONTENTFUL_SPACE_ID = 'i9q3kobl32q0'
 export const CONTENTFUL_ACCESS_TOKEN = '61db4007a6a0337a0f70fd445ea61a7a9999d4943bd8b13acd2ed7c423394d07'
 export const MAPZEN_API_KEY = 'mapzen-vw3WEMv'
+export const SAMPLE_BALLOT_FORM = 'https://form.jotform.com/81176016314146'

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -38,6 +38,18 @@ export async function FETCH_LEADER (ctx, { ward, subWard, party }) {
   ctx.commit('END_REQUEST', 'FETCH_LEADER')
 }
 
+export async function FETCH_SAMPLE_BALLOTS (ctx, { ward, subWard, party }) {
+  ctx.commit('BEGIN_REQUEST', 'FETCH_SAMPLE_BALLOTS')
+  try {
+    const sampleBallots = await api.fetchSampleBallots(ward, subWard, party)
+    ctx.commit('FETCH_SAMPLE_BALLOTS_SUCCESS', sampleBallots)
+  } catch (err) {
+    logError(err)
+    ctx.dispatch('NOTIFY', `Failed to get sample ballots`)
+  }
+  ctx.commit('END_REQUEST', 'FETCH_SAMPLE_BALLOTS')
+}
+
 export async function FETCH_COMMITTEE_PERSONS (ctx, { ward, subWard, party }) {
   ctx.commit('BEGIN_REQUEST', 'FETCH_COMMITTEE_PERSONS')
   try {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -17,6 +17,7 @@ const store = new Vuex.Store({
     citywideBoundaries: {},
     currentLeader: {
       leader: {},
+      sampleBallots: [],
       committeePersons: [],
       wardBoundaries: {}
     }

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -12,6 +12,10 @@ export function FETCH_LEADER_SUCCESS (state, leader) {
   state.currentLeader.leader = leader
 }
 
+export function FETCH_SAMPLE_BALLOTS_SUCCESS (state, sampleBallots) {
+  state.currentLeader.sampleBallots = sampleBallots
+}
+
 export function FETCH_COMMITTEE_PERSONS_SUCCESS (state, committeePersons) {
   state.currentLeader.committeePersons = committeePersons
 }

--- a/src/views/ward-leader.vue
+++ b/src/views/ward-leader.vue
@@ -168,6 +168,26 @@
                   detail="Social media"
                   label="Know a link?"></ask-detail>
               </dd>
+
+              <dt>
+                Sample Ballots
+              </dt>
+              <dd>
+                <a :href="submitSampleBallotLink">
+                  Upload a sample ballot
+                </a>
+                <ul v-if="sampleBallots.length > 0">
+                  <li
+                    v-for="ballot in sampleBallots"
+                    :key="ballot.id">
+                    <a :href="ballot.url">
+                      <figure class="image is-48x48">
+                        <img :src="ballot.url" height="48"/>
+                      </figure>
+                    </a>
+                  </li>
+                </ul>
+              </dd>
             </dl>
 
           </div>
@@ -221,9 +241,15 @@ export default {
     'ward',
     'slug'
   ],
+  data () {
+    return {
+      submitSampleBallotLink: 'https://form.jotform.com/81176016314146'
+    }
+  },
   computed: {
     ...mapState({
       leader: (state) => state.currentLeader.leader,
+      sampleBallots: (state) => state.currentLeader.sampleBallots,
       committeePersons: (state) => state.currentLeader.committeePersons,
       wardBoundaries: (state) => state.currentLeader.wardBoundaries
     }),
@@ -239,6 +265,7 @@ export default {
   },
   methods: mapActions({
     fetchLeader: 'FETCH_LEADER',
+    fetchSampleBallots: 'FETCH_SAMPLE_BALLOTS',
     fetchCommitteePersons: 'FETCH_COMMITTEE_PERSONS',
     fetchWardBoundaries: 'FETCH_WARD_BOUNDARIES'
   }),
@@ -256,6 +283,7 @@ export default {
     }
 
     this.fetchLeader(opts)
+    this.fetchSampleBallots(opts)
     this.fetchCommitteePersons(opts)
     this.fetchWardBoundaries(this.ward)
   },

--- a/src/views/ward-leader.vue
+++ b/src/views/ward-leader.vue
@@ -173,20 +173,20 @@
                 Sample Ballots
               </dt>
               <dd>
-                <a :href="submitSampleBallotLink">
-                  Upload a sample ballot
-                </a>
-                <ul v-if="sampleBallots.length > 0">
+                <ul v-if="sampleBallots.length > 0" class="sample-ballots">
                   <li
                     v-for="ballot in sampleBallots"
                     :key="ballot.id">
-                    <a :href="ballot.url">
+                    <a @click.prevent="modalUrl = ballot.url">
                       <figure class="image is-48x48">
                         <img :src="ballot.url" height="48"/>
                       </figure>
                     </a>
                   </li>
                 </ul>
+                <a :href="sampleBallotFormPrefilled">
+                  Upload a sample ballot
+                </a>
               </dd>
             </dl>
 
@@ -223,6 +223,16 @@
       </div>
     </section>
 
+    <div class="modal is-active" v-show="modalUrl">
+      <div class="modal-background" @click="modalUrl = null"/>
+      <div class="modal-content">
+        <p class="image">
+          <img :src="modalUrl">
+        </p>
+      </div>
+      <button @click="modalUrl = null" class="modal-close is-large" aria-label="close"/>
+    </div>
+
   </div>
 </template>
 
@@ -234,6 +244,7 @@ import CommitteePerson from '../components/committee-person.vue'
 import WardMap from '../components/ward-map.vue'
 import AskDetail from '../components/ask-detail.vue'
 import { formatNumber, ordinalize } from '../util'
+import { SAMPLE_BALLOT_FORM } from '../config'
 
 export default {
   props: [
@@ -243,7 +254,7 @@ export default {
   ],
   data () {
     return {
-      submitSampleBallotLink: 'https://form.jotform.com/81176016314146'
+      modalUrl: null
     }
   },
   computed: {
@@ -261,7 +272,10 @@ export default {
       'turnoutTotalPercent',
       'vacancyCount',
       'age'
-    ])
+    ]),
+    sampleBallotFormPrefilled () {
+      return `${SAMPLE_BALLOT_FORM}?ward=${this.ward}&party=${this.party}`
+    }
   },
   methods: mapActions({
     fetchLeader: 'FETCH_LEADER',
@@ -333,4 +347,14 @@ dd
 .unknown
   letter-spacing: 1px
   font-size: 80%
+
+.modal
+  z-index: 999999
+
+.sample-ballots
+  margin-bottom: 15px
+
+  li,
+  li figure
+    display: inline-block
 </style>


### PR DESCRIPTION
Fetches the "sample ballot" content type from contentful based on the ward/subward/party of the ward leader you're viewing. If any "approved" sample ballots are found, it renders thumbnails of them on the detail page. There's also a link to a jotform submission form. Behind the scenes, new jotform submissions will be pushed to contentful and marked "not approved".

[Demo site](http://phillywardleaders-sample-ballots.surge.sh/leaders/democratic/50/marian-b-tasco)

Remaining:
- [ ] Investigate whether zapier can create contentful _assets_ and relate them to an entry, rather than using the jotform url (clicking the thumbnails tries to download them because of the jotform url)
- [x] Thumbnails should show side-by-side until they run out of width, then should wrap to the next line
- [ ] It would be great to use actual thumbnails instead of the full image rendered small (faster network requests)