### PR TITLE
Show subward on baseball card front & back

### DIFF
--- a/src/components/baseball-card/index.vue
+++ b/src/components/baseball-card/index.vue
@@ -11,6 +11,7 @@
                 {{ name }}
                 <span class="ward-ordinal">
                   {{ ward | ordinalize }} Ward
+                  {{ subWard }}
                 </span>
               </h3>
               <dl>

--- a/src/components/baseball-card/svg.js
+++ b/src/components/baseball-card/svg.js
@@ -61,22 +61,21 @@ export function createFront (el, data) {
     })
 
   // Ward text line 1
-  const ordinal = ordinalize(data.ward)
-  svg.text(45, 45, ordinal)
+  svg.text(45, 40, 'Ward')
+    .attr({
+      'text-anchor': 'middle',
+      'font-family': 'arial',
+      'font-size': 12,
+      'fill': config.cardBorderColor
+    })
+
+  // Ward text line 2
+  svg.text(45, 58, data.ward + data.subWard)
     .attr({
       'text-anchor': 'middle',
       'font-family': 'arial',
       'font-weight': 'bold',
       'font-size': 18,
-      'fill': config.cardBorderColor
-    })
-
-  // Ward text line 2
-  svg.text(45, 58, 'Ward')
-    .attr({
-      'text-anchor': 'middle',
-      'font-family': 'arial',
-      'font-size': 12,
       'fill': config.cardBorderColor
     })
 


### PR DESCRIPTION
![screen shot 2018-06-25 at 7 49 29 pm](https://user-images.githubusercontent.com/761444/41881315-e649402c-78b0-11e8-9094-590cd7d19935.png)
![screen shot 2018-06-25 at 7 49 24 pm](https://user-images.githubusercontent.com/761444/41881318-eab58594-78b0-11e8-8771-c068b0340b3c.png)
Doesn't look as nice when it's a single-digit ward, but it works:
![screen shot 2018-06-25 at 7 48 41 pm](https://user-images.githubusercontent.com/761444/41881327-f6951d66-78b0-11e8-8b8c-685d20280799.png)
