### PR TITLE
fix(cards): work around SVG+backface-visibility bug

### DIFF
--- a/src/components/baseball-card/index.vue
+++ b/src/components/baseball-card/index.vue
@@ -1,8 +1,12 @@
 <template>
   <div class="column is-one-third flip-container" @click="noop">
     <div class="flipper">
-      <svg class="front" ref="front"></svg>
-      <svg class="back" ref="back"></svg>
+      <div class="front">
+        <svg ref="front"></svg>
+      </div>
+      <div class="back">
+        <svg ref="back"></svg>
+      </div>
       <svg class="contents" ref="content">
         <foreignObject width="100%" height="100%">
           <body>
@@ -122,6 +126,8 @@ export default {
   backface-visibility: hidden
   transition: 0.6s
   transform-style: preserve-3d
+  width: 100%
+  height: 100%
 
 .front
   z-index: 2

--- a/tests/components/__snapshots__/baseball-card.spec.js.snap
+++ b/tests/components/__snapshots__/baseball-card.spec.js.snap
@@ -2,7 +2,9 @@
 
 exports[`Baseball card Matches snapshot 1`] = `
 <div class="column is-one-third flip-container">
-    <div class="flipper"><svg class="front"></svg> <svg class="back"></svg> <svg class="contents">
+    <div class="flipper">
+        <div class="front"><svg></svg></div>
+        <div class="back"><svg></svg></div> <svg class="contents">
             <foreignObject width="100%" height="100%">
 
                 <body>
@@ -22,6 +24,7 @@ exports[`Baseball card Matches snapshot 1`] = `
                     </div>
                 </body>
             </foreignObject>
-        </svg></div>
+        </svg>
+    </div>
 </div>
 `;


### PR DESCRIPTION
This PR adds a `<div>` wrapper around the `<svg>`s for each side of the card, and applies the flip effect to the wrapper instead of to the SVG element

I tested this with live editing in Chrome and it seems to work, but I haven't had a chance to get set up locally and test this patch yet. I'm editing this roughly through GitHub to capture the changes I made live