### PR TITLE
fix: Fix background color issue on the app menu

### DIFF
--- a/src/components/nav-bar.vue
+++ b/src/components/nav-bar.vue
@@ -58,3 +58,9 @@ export default {
   }
 }
 </script>
+
+<style lang="sass">
+
+.navbar-end
+  background-color: #2284a1
+</style>


### PR DESCRIPTION
This pull request corrects the issue of the menu having a white background therefor rendering the menu text unviable to users.

Added a style to the` nav-bar.vue` class

**Screenshot showing the menu in 3 breakpoints. Notice the menu text is visible.**
<img width="1200" alt="Screen Shot 2022-09-06 at 2 36 21 PM" src="https://user-images.githubusercontent.com/788339/188713953-1d61c31b-2092-4457-bb42-5b96bbf48842.png">
