### PR TITLE
Shrink font further on long ward-leader names

### DIFF
--- a/src/components/baseball-card/svg.js
+++ b/src/components/baseball-card/svg.js
@@ -83,7 +83,17 @@ export function createFront(el, data) {
 
   const nameWidth = config.cardWidth - 19;
   const nameHeight = config.cardHeight - 17;
-  const nameFontSize = data.name.length < 28 ? 22 : 20;
+  // Shrink the font on longer names so hyphenated double-barrelled names
+  // like "Katherine Gilmore-Richardson" don't get cut off at the left edge
+  // of the card (see #311).
+  const nameFontSize =
+    data.name.length < 24
+      ? 22
+      : data.name.length < 28
+        ? 20
+        : data.name.length < 32
+          ? 18
+          : 16;
   const nameText = svg.text(nameWidth, nameHeight, data.name).attr({
     "text-anchor": "end",
     fill: config.cardBorderColor,


### PR DESCRIPTION
Per @pwolanin's #311. The card font size was just 22px → 20px once a name hit 28 characters, which isn't small enough for names like `Katherine Gilmore-Richardson` (the leading `K` was getting clipped past the left edge of the card).

Stepped the tiers down further so 28+ char names render at 18px and 32+ char names at 16px. Same right-anchored layout, just smaller text for the long cases.

Closes #311.